### PR TITLE
109 sample mmbot

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,3 +8,6 @@ pub use order::*;
 pub use ch::*;
 pub use logger::*;
 pub use order::*;
+
+pub const PRICE_SCALE: u32 = 4;
+pub const SIZE_SCALE: u32 = 8;

--- a/src/common/order.rs
+++ b/src/common/order.rs
@@ -348,12 +348,18 @@ impl Default for AccountChange {
 #[pyclass]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AccountStatus {
+    #[pyo3(get)]
     pub home: Decimal,
+    #[pyo3(get)]    
     pub home_free: Decimal,
+    #[pyo3(get)]    
     pub home_locked: Decimal,
 
+    #[pyo3(get)]
     pub foreign: Decimal,
+    #[pyo3(get)]    
     pub foreign_free: Decimal,
+    #[pyo3(get)]    
     pub foreign_locked: Decimal,
 }
 

--- a/src/common/order.rs
+++ b/src/common/order.rs
@@ -8,6 +8,7 @@ use polars_core::utils::arrow::bitmap::or;
 use pyo3::pyclass;
 use pyo3::pymethods;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal_macros::dec;
 use serde::de;
 use serde_derive::Deserialize;
@@ -26,7 +27,7 @@ pub struct TimeChunk {
 #[derive(Debug, Clone, Copy, PartialEq, Display, EnumString, Serialize, Deserialize)]
 pub enum OrderStatus {
     #[strum(ascii_case_insensitive)]
-    InProcess,      // 処理中
+    InProcess, // 処理中
     #[strum(ascii_case_insensitive)]
     New, // 処理中
     #[strum(
@@ -54,7 +55,7 @@ where
 }
 
 pub fn string_to_status(s: &str) -> OrderStatus {
-    let order_status:OrderStatus = s.parse().unwrap_or(OrderStatus::Error);
+    let order_status: OrderStatus = s.parse().unwrap_or(OrderStatus::Error);
 
     return order_status;
 }
@@ -104,10 +105,9 @@ impl OrderSide {
     }
 }
 
-
 pub fn orderside_deserialize<'de, D>(deserializer: D) -> Result<OrderSide, D::Error>
 where
-D: de::Deserializer<'de>,
+    D: de::Deserializer<'de>,
 {
     let s: String = de::Deserialize::deserialize(deserializer)?;
     Ok(string_to_side(&s))
@@ -136,8 +136,7 @@ impl From<&str> for OrderSide {
     }
 }
 
-
-/* 
+/*
 impl Into<String> for OrderSide {
     fn into(self) -> String {
         self.to_string()
@@ -176,7 +175,7 @@ impl OrderType {
 }
 
 pub fn ordertype_deserialize<'de, D>(deserializer: D) -> Result<OrderType, D::Error>
-    where
+where
     D: de::Deserializer<'de>,
 {
     let s: String = de::Deserialize::deserialize(deserializer)?;
@@ -310,7 +309,6 @@ impl OrderFill {
     }
 }
 
-
 #[pyclass]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AccountChange {
@@ -348,18 +346,12 @@ impl Default for AccountChange {
 #[pyclass]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AccountStatus {
-    #[pyo3(get)]
     pub home: Decimal,
-    #[pyo3(get)]    
     pub home_free: Decimal,
-    #[pyo3(get)]    
     pub home_locked: Decimal,
 
-    #[pyo3(get)]
     pub foreign: Decimal,
-    #[pyo3(get)]    
     pub foreign_free: Decimal,
-    #[pyo3(get)]    
     pub foreign_locked: Decimal,
 }
 
@@ -386,6 +378,30 @@ impl AccountStatus {
     pub fn __repr__(&self) -> String {
         serde_json::to_string(&self).unwrap()
     }
+    #[getter]
+    pub fn get_home(&self) -> f64 {
+        return self.home.to_f64().unwrap();
+    }
+    #[getter]
+    pub fn get_home_free(&self) -> f64 {
+        return self.home_free.to_f64().unwrap();
+    }
+    #[getter]
+    pub fn get_home_locked(&self) -> f64 {
+        return self.home_locked.to_f64().unwrap();
+    }
+    #[getter]
+    pub fn get_foreign(&self) -> f64 {
+        return self.foreign.to_f64().unwrap();
+    }
+    #[getter]
+    pub fn get_foreign_free(&self) -> f64 {
+        return self.foreign_free.to_f64().unwrap();
+    }
+    #[getter]
+    pub fn get_foreign_locked(&self) -> f64 {
+        return self.foreign_locked.to_f64().unwrap();
+    }
 }
 
 #[pyclass]
@@ -397,20 +413,20 @@ pub struct Order {
     #[pyo3(get)]
     pub create_time: MicroSec, // in us
     #[pyo3(get)]
-    pub order_id: String,      // YYYY-MM-DD-SEQ
+    pub order_id: String, // YYYY-MM-DD-SEQ
     #[pyo3(get)]
     pub client_order_id: String,
     #[pyo3(get)]
     pub order_side: OrderSide,
     #[pyo3(get)]
     pub order_type: OrderType,
-    #[pyo3(get)]
+    // #[pyo3(get)]
     pub order_price: Decimal, // in Market order, price is 0.0
-    #[pyo3(get)]
-    pub order_size: Decimal,  // in foreign
+    //#[pyo3(get)]
+    pub order_size: Decimal, // in foreign
 
     // 以後オーダーの状況に応じてUpdateされる。
-    #[pyo3(get)]
+    //#[pyo3(get)]
     pub remain_size: Decimal, // 残数
     #[pyo3(get)]
     pub status: OrderStatus,
@@ -418,13 +434,13 @@ pub struct Order {
     pub transaction_id: String,
     #[pyo3(get)]
     pub update_time: MicroSec,
-    #[pyo3(get)]
+    //#[pyo3(get)]
     pub execute_price: Decimal,
-    #[pyo3(get)]
+    //#[pyo3(get)]
     pub execute_size: Decimal,
-    #[pyo3(get)]
+    //#[pyo3(get)]
     pub quote_vol: Decimal,
-    #[pyo3(get)]
+    //#[pyo3(get)]
     pub commission: Decimal,
     #[pyo3(get)]
     pub commission_asset: String,
@@ -481,7 +497,7 @@ impl Order {
     }
 
     pub fn update(&mut self, order: &Order) {
-        /* unchange feild 
+        /* unchange feild
         order_id,
         client_order_id,
         order_side,
@@ -504,6 +520,41 @@ impl Order {
         if order.message.len() > 0 {
             self.message = order.message.clone();
         }
+    }
+
+    #[getter]
+    pub fn get_order_price(&self) -> f64 {
+        return self.order_price.to_f64().unwrap();
+    }
+    //#[pyo3(get)]
+    #[getter]
+    pub fn get_order_size(&self) -> f64 {
+        return self.order_size.to_f64().unwrap();
+    }
+
+    #[getter]
+    pub fn get_remain_size(&self) -> f64 {
+        return self.remain_size.to_f64().unwrap();
+    }
+
+    #[getter]
+    pub fn get_execute_price(&self) -> f64 {
+        return self.execute_price.to_f64().unwrap();
+    }
+
+    #[getter]
+    pub fn get_execute_size(&self) -> f64 {
+        return self.execute_size.to_f64().unwrap();
+    }
+
+    #[getter]
+    pub fn get_quote_vol(&self) -> f64 {
+        return self.quote_vol.to_f64().unwrap();
+    }
+
+    #[getter]
+    pub fn get_commission(&self) -> f64 {
+        return self.commission.to_f64().unwrap();
     }
 }
 

--- a/src/exchange/binance/market.rs
+++ b/src/exchange/binance/market.rs
@@ -4,6 +4,7 @@ use chrono::Datelike;
 use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
 use csv::StringRecord;
+use hmac::digest::crypto_common::BlockSizeUser;
 use numpy::PyArray2;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
@@ -22,6 +23,8 @@ use std::time::Duration;
 use std::{fs, thread};
 
 use crate::common::MultiChannel;
+use crate::common::PRICE_SCALE;
+use crate::common::SIZE_SCALE;
 use crate::common::convert_pyresult_vec;
 use crate::common::{convert_pyresult, MarketMessage, MarketStream};
 use crate::common::{time_string, DAYS};
@@ -434,6 +437,9 @@ impl BinanceMarket {
         size: Decimal,
         client_order_id: Option<&str>,
     ) -> PyResult<BinanceOrderResponse> {
+        let price = price.round_dp(PRICE_SCALE);
+        let size = size.round_dp(SIZE_SCALE);
+
         let response = new_limit_order(&self.config, side, price, size, client_order_id);
 
         convert_pyresult(response)
@@ -447,6 +453,9 @@ impl BinanceMarket {
         size: Decimal,
         client_order_id: Option<&str>,
     ) -> PyResult<Vec<Order>> {
+        let price = price.round_dp(PRICE_SCALE);
+        let size = size.round_dp(SIZE_SCALE);
+
         let response = new_limit_order(&self.config, side, price, size, client_order_id);
 
         convert_pyresult(response)
@@ -458,6 +467,8 @@ impl BinanceMarket {
         size: Decimal,
         client_order_id: Option<&str>,
     ) -> PyResult<BinanceOrderResponse> {
+        let size = size.round_dp(SIZE_SCALE);
+
         let response = new_market_order(&self.config, side, size, client_order_id);
 
         convert_pyresult(response)
@@ -469,6 +480,8 @@ impl BinanceMarket {
         size: Decimal,
         client_order_id: Option<&str>,
     ) -> PyResult<Vec<Order>> {
+        let size = size.round_dp(SIZE_SCALE);
+
         let response = new_market_order(&self.config, side, size, client_order_id);
 
         convert_pyresult(response)

--- a/src/exchange/binance/market.rs
+++ b/src/exchange/binance/market.rs
@@ -477,13 +477,17 @@ impl BinanceMarket {
     pub fn cancel_order(&self, order_id: &str) -> PyResult<Order> {
         let response = cancel_order(&self.config, order_id);
 
-        convert_pyresult(response)
+        return convert_pyresult(response);
     }
 
     pub fn cancel_all_orders(&self) -> PyResult<Vec<Order>> {
         let response = cancell_all_orders(&self.config);
-        // TODO: imple
-        convert_pyresult_vec(response)
+
+        if response.is_ok() {
+            return convert_pyresult_vec(response);
+        }
+
+        return PyResult::Ok(vec![]);
     }
 
     #[getter]

--- a/src/exchange/binance/rest.rs
+++ b/src/exchange/binance/rest.rs
@@ -579,6 +579,17 @@ pub fn new_market_order(
     parse_response::<BinanceOrderResponse>(binance_post_sign(&config, path, body.as_str()))
 }
 
+// https://binance-docs.github.io/apidocs/spot/en/#query-order-user_data
+/*
+pub fn alter_order(
+    config: &BinanceConfig,
+    order_id: &str,
+    price: Decimal,
+    size: Decimal,
+) -> Result<BinanceOrderResponse, String> {
+}
+*/
+
 /// https://binance-docs.github.io/apidocs/spot/en/#cancel-all-open-orders-on-a-symbol-trade
 pub fn cancel_order(
     config: &BinanceConfig,

--- a/src/exchange/mod.rs
+++ b/src/exchange/mod.rs
@@ -989,8 +989,8 @@ impl Board {
             sizes.push(item.size.to_f64().unwrap());
         }
 
-        let prices = Series::new("Price", prices);
-        let sizes = Series::new("Size", sizes);
+        let prices = Series::new("price", prices);
+        let sizes = Series::new("size", sizes);
 
         let df = DataFrame::new(vec![prices, sizes]).unwrap();
 

--- a/src/test/binance_test/market.ipynb
+++ b/src/test/binance_test/market.ipynb
@@ -53,17 +53,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-09-27T12:47:45.439Z \u001b[35mDEBUG\u001b[0m [rbot::exchange::binance::rest] path/api/v3/order / body: symbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.05&newClientOrderId=BTCUSDT&recvWindow=6000&timestamp=1695818865438&signature=7ffb3d2e17eb73ebb70300cd5ea103e051e04ad4ff4a405bec2697700910fa85\n",
-      "2023-09-27T12:47:45.439Z \u001b[35mDEBUG\u001b[0m [reqwest::connect] starting new connection: https://testnet.binance.vision/\n",
-      "2023-09-27T12:47:45.598Z \u001b[35mDEBUG\u001b[0m [rbot::exchange] Response code = 200 / download size None / method(POST) / URL = https://testnet.binance.vision/api/v3/order / pathsymbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.05&newClientOrderId=BTCUSDT&recvWindow=6000&timestamp=1695818865438&signature=7ffb3d2e17eb73ebb70300cd5ea103e051e04ad4ff4a405bec2697700910fa85\n"
+      "2023-09-27T22:34:33.859Z \u001b[35mDEBUG\u001b[0m [rbot::exchange::binance::rest] path/api/v3/order / body: symbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.05&newClientOrderId=BTCUSDT&recvWindow=6000&timestamp=1695854073857&signature=524e7ff6b81d7090cf9b6f8fd93d0e1e4d5c8e8c2f024eba87a176849d85c77e\n",
+      "2023-09-27T22:34:33.863Z \u001b[35mDEBUG\u001b[0m [reqwest::connect] starting new connection: https://testnet.binance.vision/\n",
+      "2023-09-27T22:34:34.138Z \u001b[35mDEBUG\u001b[0m [rbot::exchange] Response code = 200 / download size None / method(POST) / URL = https://testnet.binance.vision/api/v3/order / pathsymbol=BTCUSDT&side=BUY&type=MARKET&quantity=0.05&newClientOrderId=BTCUSDT&recvWindow=6000&timestamp=1695854073857&signature=524e7ff6b81d7090cf9b6f8fd93d0e1e4d5c8e8c2f024eba87a176849d85c77e\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{\"symbol\":\"BTCUSDT\",\"create_time\":1695818865607000,\"order_id\":\"10336589\",\"client_order_id\":\"BTCUSDT\",\"order_side\":\"Buy\",\"order_type\":\"Market\",\"order_price\":\"0.00000000\",\"order_size\":\"0.05000000\",\"remain_size\":\"0.04900000\",\"status\":\"PartiallyFilled\",\"transaction_id\":\"1772917\",\"update_time\":0,\"execute_price\":\"26695.69000000\",\"execute_size\":\"0.00100000\",\"quote_vol\":\"26.6956900000000000\",\"commission\":\"0.00000000\",\"commission_asset\":\"BTC\",\"is_maker\":false,\"message\":\"\"},\n",
-       " {\"symbol\":\"BTCUSDT\",\"create_time\":1695818865607000,\"order_id\":\"10336589\",\"client_order_id\":\"BTCUSDT\",\"order_side\":\"Buy\",\"order_type\":\"Market\",\"order_price\":\"0.00000000\",\"order_size\":\"0.05000000\",\"remain_size\":\"0.01214000\",\"status\":\"PartiallyFilled\",\"transaction_id\":\"1772918\",\"update_time\":0,\"execute_price\":\"26695.70000000\",\"execute_size\":\"0.03686000\",\"quote_vol\":\"984.0035020000000000\",\"commission\":\"0.00000000\",\"commission_asset\":\"BTC\",\"is_maker\":false,\"message\":\"\"},\n",
-       " {\"symbol\":\"BTCUSDT\",\"create_time\":1695818865607000,\"order_id\":\"10336589\",\"client_order_id\":\"BTCUSDT\",\"order_side\":\"Buy\",\"order_type\":\"Market\",\"order_price\":\"0.00000000\",\"order_size\":\"0.05000000\",\"remain_size\":\"0.00000000\",\"status\":\"Filled\",\"transaction_id\":\"1772919\",\"update_time\":0,\"execute_price\":\"26695.73000000\",\"execute_size\":\"0.01214000\",\"quote_vol\":\"324.0861622000000000\",\"commission\":\"0.00000000\",\"commission_asset\":\"BTC\",\"is_maker\":false,\"message\":\"\"}]"
+       "[{\"symbol\":\"BTCUSDT\",\"create_time\":1695854074231000,\"order_id\":\"10576352\",\"client_order_id\":\"BTCUSDT\",\"order_side\":\"Buy\",\"order_type\":\"Market\",\"order_price\":\"0.00000000\",\"order_size\":\"0.05000000\",\"remain_size\":\"0.04909000\",\"status\":\"PartiallyFilled\",\"transaction_id\":\"1828695\",\"update_time\":0,\"execute_price\":\"26317.26000000\",\"execute_size\":\"0.00091000\",\"quote_vol\":\"23.9487066000000000\",\"commission\":\"0.00000000\",\"commission_asset\":\"BTC\",\"is_maker\":false,\"message\":\"\"},\n",
+       " {\"symbol\":\"BTCUSDT\",\"create_time\":1695854074231000,\"order_id\":\"10576352\",\"client_order_id\":\"BTCUSDT\",\"order_side\":\"Buy\",\"order_type\":\"Market\",\"order_price\":\"0.00000000\",\"order_size\":\"0.05000000\",\"remain_size\":\"0.02802600\",\"status\":\"PartiallyFilled\",\"transaction_id\":\"1828696\",\"update_time\":0,\"execute_price\":\"26317.27000000\",\"execute_size\":\"0.02106400\",\"quote_vol\":\"554.3469752800000000\",\"commission\":\"0.00000000\",\"commission_asset\":\"BTC\",\"is_maker\":false,\"message\":\"\"},\n",
+       " {\"symbol\":\"BTCUSDT\",\"create_time\":1695854074231000,\"order_id\":\"10576352\",\"client_order_id\":\"BTCUSDT\",\"order_side\":\"Buy\",\"order_type\":\"Market\",\"order_price\":\"0.00000000\",\"order_size\":\"0.05000000\",\"remain_size\":\"0.00000000\",\"status\":\"Filled\",\"transaction_id\":\"1828697\",\"update_time\":0,\"execute_price\":\"26317.28000000\",\"execute_size\":\"0.02802600\",\"quote_vol\":\"737.5680892800000000\",\"commission\":\"0.00000000\",\"commission_asset\":\"BTC\",\"is_maker\":false,\"message\":\"\"}]"
       ]
      },
      "execution_count": 3,
@@ -77,11 +77,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2023-09-27T22:34:35.740Z \u001b[35mDEBUG\u001b[0m [rbot::exchange::binance::rest] path/api/v3/order / body: symbol=BTCUSDT&side=SELL&type=LIMIT&timeInForce=GTC&quantity=0.001&price=28000.1&recvWindow=6000&timestamp=1695854075740&signature=0166b3ca6055ad51f4cc4450b6320f61664f23dd91a6b7fc1239f24610d78fc4\n",
+      "2023-09-27T22:34:35.740Z \u001b[35mDEBUG\u001b[0m [reqwest::connect] starting new connection: https://testnet.binance.vision/\n",
+      "2023-09-27T22:34:35.815Z \u001b[35mDEBUG\u001b[0m [rbot::exchange] Response code = 200 / download size None / method(POST) / URL = https://testnet.binance.vision/api/v3/order / pathsymbol=BTCUSDT&side=SELL&type=LIMIT&timeInForce=GTC&quantity=0.001&price=28000.1&recvWindow=6000&timestamp=1695854075740&signature=0166b3ca6055ad51f4cc4450b6320f61664f23dd91a6b7fc1239f24610d78fc4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\"><thead><tr><th>symbol</th><th>create_time</th><th>order_id</th><th>client_order_id</th><th>order_side</th><th>order_type</th><th>order_price</th><th>order_size</th><th>remain_size</th><th>status</th><th>transaction_id</th><th>update_time</th><th>execute_price</th><th>execute_size</th><th>quote_vol</th><th>commission</th><th>commission_asset</th><th>is_maker</th><th>message</th></tr></thead><tbody><tr><td>BTCUSDT</td><td>1695854075899000</td><td>10576362</td><td>6tUOgDzxFx1IoiL6gVKPvd</td><td>Sell</td><td>Limit</td><td>28000.10000000</td><td>0.00100000</td><td>0.00100000</td><td>New</td><td></td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td></td><td>False</td><td></td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "o = binance.limit_order(OrderSide.Sell, 28000.1, 0.001)\n",
+    "price = 28000\n",
+    "\n",
+    "o = binance.limit_order(OrderSide.Sell, price + 0.1, 0.001)\n",
     "HTML(json2html.convert(json=o.__str__()))"
    ]
   },

--- a/src/test/binance_test/market.ipynb
+++ b/src/test/binance_test/market.ipynb
@@ -364,7 +364,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.2"
   },
   "orig_nbformat": 4
  },

--- a/src/test/binance_test/mmbot.py
+++ b/src/test/binance_test/mmbot.py
@@ -9,7 +9,6 @@ from rbot import OrderSide
 from rbot import time_string
 from threading import Thread
 from time import sleep
-from decimal import *
 
 class MyAgent:
     def __init__(self):
@@ -26,28 +25,29 @@ class MyAgent:
         ask_edge = session.asks[0]['price'][0]
         bid_edge = session.bids[0]['price'][0]
 
+
         if len(session.sell_orders) == 0:
-            print(">Sell Order, price: ", ask_edge - 0.1, "size: ", 0.001)
-            session.limit_order(OrderSide.Sell, ask_edge - 0.1, 0.001)
+            print(">Sell Order, price: ", ask_edge + 0.5, "size: ", 0.001)
+            session.limit_order(OrderSide.Sell, ask_edge + 0.5, 0.001)
         else:
             sell_price = session.sell_orders[0].order_price
-            if ask_edge - sell_price > 1.0:
-                print(">Sell Order, price: ", ask_edge - 0.1, "size: ", 0.001)
+            if sell_price - ask_edge  > 5.0:
+                print(">Sell Order, change price: ", ask_edge, "size: ", 0.001)
                 session.cancel_order(session.sell_orders[0].order_id)
-                session.limit_order(OrderSide.Sell, ask_edge - 0.1, 0.001)
+                session.limit_order(OrderSide.Sell, ask_edge, 0.001)
 
         if len(session.buy_orders) == 0:
-            print(">Buy Order, price: ", bid_edge + 0.1, "size: ", 0.001)
-            session.limit_order(OrderSide.Buy, bid_edge + 0.1, 0.001)
+            print(">Buy Order, price: ", bid_edge - 0.5, "size: ", 0.001)
+            session.limit_order(OrderSide.Buy, bid_edge - 0.5, 0.001)
         else:            
             buy_price = session.buy_orders[0].order_price
-            if  Decimal(bid_edge) - buy_price > 1.0:
-                print(">Buy Order, price: ", bid_edge + 0.1, "size: ", 0.001)
+            if  bid_edge - buy_price > 5.0:
+                print(">Buy Order change, price: ", bid_edge, "size: ", 0.001)
                 session.cancel_order(session.buy_orders[0].order_id)
-                session.limit_order(OrderSide.Buy, bid_edge + 0.1, 0.001)
-        
+                session.limit_order(OrderSide.Buy, bid_edge, 0.001)
        
-    
+
+    """    
     def on_update(self, session, updated_order):
         if len(session.asks) == 0 or len(session.bids) == 0:
             return
@@ -67,7 +67,7 @@ class MyAgent:
         print("buy orders", session.buy_orders)
         print("sell orders", session.sell_orders)
 
-        """
+
         if len(session.sell_orders) == 0:
             print(">Sell Order, price: ", ask_edge - 0.01, "size: ", 0.001)
             session.limit_order(OrderSide.Sell, ask_edge, 0.001)
@@ -75,14 +75,13 @@ class MyAgent:
         if len(session.buy_orders) == 0:
             print(">Buy Order, price: ", bid_edge + 0.01, "size: ", 0.001)
             session.limit_order(OrderSide.Buy, bid_edge, 0.001)
-        """
+
         print("-------------------")
+    """
     
     def on_account_update(self, session, account):
-        if len(session.bids) == 0:
-            return 
-        print("account update: ", session.current_time, account)
-        print("TOTAL ASSETS: ", account.home + account.foreign * Decimal(session.bids[0]['price'][0]))
+        #print("account update: ", session.current_time, account)
+        print("TOTAL ASSETS: ", account.home + account.foreign * session.bids[0]['price'][0])
 
     
 market = BinanceMarket(BinanceConfig.TEST_BTCUSDT)

--- a/src/test/binance_test/mmbot.py
+++ b/src/test/binance_test/mmbot.py
@@ -1,0 +1,103 @@
+
+from rbot import Session
+from rbot import Runner
+from rbot import BinanceConfig
+from rbot import BinanceMarket
+from rbot import init_debug_log
+from rbot import init_log
+from rbot import OrderSide
+from rbot import time_string
+from threading import Thread
+from time import sleep
+from decimal import *
+
+class MyAgent:
+    def __init__(self):
+        self.oneshot = True
+    
+    def on_clock(self):
+        pass
+
+
+    def on_tick(self, session, side, price, size):
+        if len(session.asks) == 0 or len(session.bids) == 0:
+            return
+
+        ask_edge = session.asks[0]['price'][0]
+        bid_edge = session.bids[0]['price'][0]
+
+        if len(session.sell_orders) == 0:
+            print(">Sell Order, price: ", ask_edge - 0.1, "size: ", 0.001)
+            session.limit_order(OrderSide.Sell, ask_edge - 0.1, 0.001)
+        else:
+            sell_price = session.sell_orders[0].order_price
+            if ask_edge - sell_price > 1.0:
+                print(">Sell Order, price: ", ask_edge - 0.1, "size: ", 0.001)
+                session.cancel_order(session.sell_orders[0].order_id)
+                session.limit_order(OrderSide.Sell, ask_edge - 0.1, 0.001)
+
+        if len(session.buy_orders) == 0:
+            print(">Buy Order, price: ", bid_edge + 0.1, "size: ", 0.001)
+            session.limit_order(OrderSide.Buy, bid_edge + 0.1, 0.001)
+        else:            
+            buy_price = session.buy_orders[0].order_price
+            if  Decimal(bid_edge) - buy_price > 1.0:
+                print(">Buy Order, price: ", bid_edge + 0.1, "size: ", 0.001)
+                session.cancel_order(session.buy_orders[0].order_id)
+                session.limit_order(OrderSide.Buy, bid_edge + 0.1, 0.001)
+        
+       
+    
+    def on_update(self, session, updated_order):
+        if len(session.asks) == 0 or len(session.bids) == 0:
+            return
+
+        ask_edge = session.asks[0]['price'][0]
+        bid_edge = session.bids[0]['price'][0]
+
+        print("update: ", time_string(session.current_time), 
+              updated_order.order_side,
+              updated_order.order_price,
+              updated_order.order_size,
+              updated_order.execute_size,
+              time_string(updated_order.create_time),
+              time_string(updated_order.update_time),
+              updated_order.status,
+              )
+        print("buy orders", session.buy_orders)
+        print("sell orders", session.sell_orders)
+
+        """
+        if len(session.sell_orders) == 0:
+            print(">Sell Order, price: ", ask_edge - 0.01, "size: ", 0.001)
+            session.limit_order(OrderSide.Sell, ask_edge, 0.001)
+            
+        if len(session.buy_orders) == 0:
+            print(">Buy Order, price: ", bid_edge + 0.01, "size: ", 0.001)
+            session.limit_order(OrderSide.Buy, bid_edge, 0.001)
+        """
+        print("-------------------")
+    
+    def on_account_update(self, session, account):
+        if len(session.bids) == 0:
+            return 
+        print("account update: ", session.current_time, account)
+        print("TOTAL ASSETS: ", account.home + account.foreign * Decimal(session.bids[0]['price'][0]))
+
+    
+market = BinanceMarket(BinanceConfig.TEST_BTCUSDT)
+
+market.cancel_all_orders()
+
+print(BinanceConfig.TEST_BTCUSDT)
+
+market.start_market_stream()
+market.start_user_stream()
+    
+agent = MyAgent()
+runner = Runner()
+
+
+
+
+runner.run(market, agent)

--- a/src/test/binance_test/nullagent.py
+++ b/src/test/binance_test/nullagent.py
@@ -15,13 +15,12 @@ class MyAgent:
     def on_clock(self):
         pass
 
-    """
+
     def on_tick(self, session, side, price, size):
         print("tick: ", session.current_time, side, price, size)
         
         market.limit_order(OrderSide.Sell, price + 100, 0.001)        
         pass
-    """
     
     def on_update(self, session, updated_order):
         print("update: ", time_string(session.current_time), 

--- a/src/test/polars/polars_test.ipynb
+++ b/src/test/polars/polars_test.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import polars as pl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "price = pl.Series(\"price\", [1, 2, 3, 4, 5])\n",
+    "quantity = pl.Series(\"quantity\", [10, 20, 30, 40, 50])\n",
+    "\n",
+    "df = pl.DataFrame({\"price\": price, \"quantity\": quantity})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[0]['price'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
#117 キャンセルオーダー実装
#116 Rust->Pythonへはf64でexport. 逆側は小数点以下で丸めてDecimal型を作成
#109 いたの端に両建てするボットを作成。動作確認としてはOK
#108 BoardをPorlasにした。
#105 New, Cancelの実装済み
