### PR TITLE
Boardserver runs in separate thread

### DIFF
--- a/rbot/test/bybit_test/nullagent.py
+++ b/rbot/test/bybit_test/nullagent.py
@@ -14,7 +14,7 @@ class SkeltonAgent:      # クラス名は任意です
         Args:
             session: セッション情報（Botの初期化時用に渡されます）
         """
-        session.clock_interval_sec = 60        # 10秒ごとにon_clockを呼び出します。
+        session.clock_interval_sec = 10        # 10秒ごとにon_clockを呼び出します。
 
     
     def on_tick(self, session, side, price, size):
@@ -27,7 +27,7 @@ class SkeltonAgent:      # クラス名は任意です
         """
         
         # on_tickは高頻度によびだされるので、100回に1回だけ内容をプリントします。
-        #print("on_tick: ", side, price, size)
+        print("on_tick: ", side, price, size)
         pass
     
     def on_clock(self, session, clock):
@@ -38,6 +38,9 @@ class SkeltonAgent:      # クラス名は任意です
             session: セッション情報（市況情報の取得や注文するために利用します)        
             clock: 現在時刻です。エポック時間からのマイクロ秒で表されます。
         """
+        bit, ask = session.board
+        
+        print(bit, ask)
         # 現在の時刻をプリントします。
         print("on_clock: ", clock, ": ", time_string(clock))
         session.market_order("Buy", 0.001)

--- a/rbot_lib/src/net/udp.rs
+++ b/rbot_lib/src/net/udp.rs
@@ -224,9 +224,12 @@ impl UdpReceiver {
         let mut udp = Self::open();
         let (tx, rx) = crossbeam_channel::unbounded::<MarketMessage>();
 
+        log::debug!("open_channel: {}/{}/{}/{}", exchange, category, symbol, agent_id);
+
         // TOD: change to async
         std::thread::spawn(move || loop {
             let msg = udp.receive_message();
+            log::debug!("message: {:?}", msg);
 
             if msg.is_err() {
                 break;

--- a/rbot_server/src/server.rs
+++ b/rbot_server/src/server.rs
@@ -67,20 +67,24 @@ async fn get_board_vec(path: web::Path<PathInfo>) -> impl Responder {
 
 
 pub fn start_board_server() -> anyhow::Result<()> {
-    let sys = actix_rt::System::new();
+    std::thread::spawn(|| {
+        let sys = actix_rt::System::new();
 
-    let server = HttpServer::new(|| 
-        App::new()
-        .service(greet)
-        .service(get_board_json)
-        .service(get_board_vec)
-        )
-        
-        .bind("127.0.0.1:8080")
-        .expect("Failed to bind server")
-        .run();
+        let server = HttpServer::new(|| 
+            App::new()
+            .service(greet)
+            .service(get_board_json)
+            .service(get_board_vec)
+            )
+            
+            .bind("127.0.0.1:8080")
+            .expect("Failed to bind server")
+            .run();
+    
+        sys.block_on(server).unwrap();
+    });
 
-    sys.block_on(server).unwrap();
+    log::debug!("start_board_server: started");
 
     Ok(())
 }


### PR DESCRIPTION
Board server runs in separated thread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- セッションのクロック間隔を60秒から10秒に短縮しました。
	- サーバーの初期化プロセスに新たな並行性レベルを導入し、メインスレッドがサーバーの起動を待たずに実行を続けられるようにしました。

- **改善点**
	- デバッグ情報の出力を追加し、より詳細な実行フローの可視化を実現しました。
	- 特定のイベントに対するプリントステートメントを導入しました。

- **リファクタリング**
	- `subscribe`メソッドと`subscribe_all`メソッドのシグネチャを明確化しました。
	- コードのフォーマットを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->