### PR TITLE
Fix: edge_price after start_market_stream

### DIFF
--- a/MEMO/changes.txt
+++ b/MEMO/changes.txt
@@ -1,0 +1,12 @@
+* BinanceMarket::download_gap
+    Add flush on each print progress.
+
+* reflesh bord when start_market_stream
+    ->  for edge price
+
+* BybytMarket::download_gap
+    Add verbose print
+    Fix: when gap is end with now(time:0)
+
+<TODO>
+* OHLC, OHLCVV, VAPの合計値をあわせる（おそらく小数点以下の誤差でずれが発生している）

--- a/exchanges/binance/src/market.rs
+++ b/exchanges/binance/src/market.rs
@@ -302,7 +302,7 @@ impl BinanceMarket {
     }
 
     #[getter]
-    fn get_edge_price(&self) -> anyhow::Result<(Decimal, Decimal)> {
+    fn get_edge_price(&mut self) -> anyhow::Result<(Decimal, Decimal)> {
         MarketImpl::get_edge_price(self)
     }
 
@@ -633,6 +633,7 @@ impl BinanceMarket {
             if let Some(t) = unfix_end.clone() {
                 println!("unfix_end  : {:?}", t.__str__());
             }
+            flush_log();
         }
 
         let unfix_start_id = if let Some(trade) = unfix_start {
@@ -687,6 +688,7 @@ impl BinanceMarket {
                     trades[l - 1].time,
                     trades[l - 1].id
                 );
+                flush_log();
             }
 
             let trade_id = trades[l - 1].id.parse::<i64>()?;
@@ -810,6 +812,19 @@ mod test_market_impl {
         let mut market = BinanceMarket::new(&server, &market_config);
 
         let rec = market.download_latest(true).unwrap();
+        assert!(rec > 0);
+    }
+
+    #[test]
+    fn test_download_gap() {
+
+        use super::*;
+        let server = BinanceServerConfig::new(true);
+        let market_config = BinanceConfig::BTCUSDT();
+
+        let mut market = BinanceMarket::new(&server, &market_config);
+
+        let rec = market.download_gap(false, true).unwrap();
         assert!(rec > 0);
     }
 

--- a/rbot/src/lib.rs
+++ b/rbot/src/lib.rs
@@ -4,9 +4,8 @@
 
 use pyo3::{pymodule, types::PyModule, wrap_pyfunction, PyResult, Python};
 use rbot_lib::{common::{
-    get_orderbook, get_orderbook_list, init_debug_log, init_log, time_string, 
-    AccountPair, AccountCoins, BoardItem, MarketConfig, Order, OrderSide, OrderStatus, OrderType, Trade, DAYS, DAYS_BEFORE, FLOOR_SEC, HHMM, MIN, NOW, SEC
-}, db::get_db_root, db::set_db_root};
+    get_orderbook, get_orderbook_list, init_debug_log, init_log, time_string, AccountCoins, AccountPair, BoardItem, MarketConfig, MarketMessage, Order, OrderSide, OrderStatus, OrderType, Trade, DAYS, DAYS_BEFORE, FLOOR_SEC, HHMM, MIN, NOW, SEC
+}, db::{get_db_root, set_db_root}};
 
 use rbot_session::{Logger, Session, Runner, ExecuteMode};
 use bybit::{Bybit, BybitConfig};
@@ -59,6 +58,7 @@ fn rbot(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Runner>()?;
     m.add_class::<ExecuteMode>()?;
 
+    m.add_class::<MarketMessage>()?;
     //m.add_class::<Broadcast>()?;
     //m.add_class::<BroadcastMessage>()?;
     

--- a/rbot_lib/src/common/config.rs
+++ b/rbot_lib/src/common/config.rs
@@ -1,7 +1,7 @@
 // Copyright(c) 2022-4. yasstake. All rights reserved.
 // ABUSOLUTELY NO WARRANTY.
 
-use pyo3::pyclass;
+use pyo3::{pyclass, pymethods};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde_derive::{Serialize, Deserialize};
@@ -68,6 +68,18 @@ pub struct MarketConfig {
     #[pyo3(set)]
     pub public_subscribe_channel: Vec<String>,
 }
+
+#[pymethods]
+impl MarketConfig {
+    pub fn __repr__(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+
+    pub fn __str__(&self) -> String {
+        self.__repr__()
+    }
+}
+
 
 impl MarketConfig {
     pub fn new(
@@ -157,47 +169,6 @@ impl Default for MarketConfig {
 
 }
 
-/*
-pub struct ServerConfigStruct {
-    exchange_name: String, 
-    trade_category: String,
-    home_currency: String,
-    foreign_currency: String,
-    price_scale: u32,
-    size_scale: u32,
-    board_depth: u32,
-}
-
-impl ServerConfig for ServerConfigStruct {
-    fn get_exchange_name(&self) -> String {
-        self.exchange_name.clone()
-    }
-
-    fn get_historical_web_base(&self) -> String {
-        todo!()
-    }
-
-    fn get_public_ws_server(&self) -> String {
-        todo!()
-    }
-
-    fn get_user_ws_server(&self) -> String {
-        todo!()
-    }
-
-    fn get_rest_server(&self) -> String {
-        todo!()
-    }
-
-    fn get_api_key(&self) -> SecretString {
-        todo!()
-    }
-
-    fn get_api_secret(&self) -> SecretString {
-        todo!()
-    }
-}
-*/
 
 
 pub trait ServerConfig : Send + Sync {

--- a/rbot_lib/src/common/orderbook.rs
+++ b/rbot_lib/src/common/orderbook.rs
@@ -381,14 +381,18 @@ impl OrderBookRaw {
         self.bids.to_dataframe()
     }
 
-    pub fn get_edge_price(&mut self) -> (Decimal, Decimal) {
+    pub fn get_edge_price(&mut self) -> anyhow::Result<(Decimal, Decimal)> {
         let bids = self.bids.get();
         let asks = self.asks.get();
+
+        if bids.len() == 0 || asks.len() == 0 {
+            return Err(anyhow::anyhow!("board has no data"));
+        }
 
         let bid_price = bids.first().unwrap().price;
         let ask_price = asks.first().unwrap().price;
 
-        return (bid_price, ask_price);
+        return Ok((bid_price, ask_price));
     }
 
     pub fn get_asks(&self) -> Vec<BoardItem> {
@@ -533,7 +537,7 @@ impl OrderBook {
         Ok(json.to_string())
     }
 
-    pub fn get_edge_price(&self) -> (Decimal, Decimal) {
+    pub fn get_edge_price(&self) -> anyhow::Result<(Decimal, Decimal)> {
         self.board.lock().unwrap().get_edge_price()
     }
 

--- a/rbot_lib/src/net/rest.rs
+++ b/rbot_lib/src/net/rest.rs
@@ -38,11 +38,8 @@ where
     async fn get_board_snapshot(server: &T, config: &MarketConfig)
         -> anyhow::Result<BoardTransfer>;
 
-    async fn get_recent_trades(
-        server: &T,
-        config: &MarketConfig,
-    ) -> anyhow::Result<Vec<Trade>>;
-    
+    async fn get_recent_trades(server: &T, config: &MarketConfig) -> anyhow::Result<Vec<Trade>>;
+
     fn get_trade_klines(
         server: &T,
         config: &MarketConfig,
@@ -604,22 +601,13 @@ pub async fn do_rest_request(
         .await
         .with_context(|| format!("URL get error {url:}"))?;
 
-    log::debug!(
-        "Response code = {} / content size {:?} / method({:?}) / URL = {} ",
-        response.status().as_str(),
-        response.content_length(),
-        method,
-        url,
-    );
-
     if response.status().as_str() != "200" {
         return Err(anyhow!(
-            "Response code = {} / download size {:?} / method({:?}) / URL = {} / path = {}",
+            "Response code = {} / download size {:?} / method({:?}) /  response body = {}",
             response.status().as_str(),
             response.content_length(),
             method,
-            url,
-            body
+            &body,
         ));
     }
 
@@ -627,8 +615,6 @@ pub async fn do_rest_request(
         .text()
         .await
         .with_context(|| format!("response text error"))?;
-
-    log::debug!("body{}", body);
 
     Ok(body)
 }


### PR DESCRIPTION
* BinanceMarket::download_gap
    Add flush on each print progress.

* reflesh bord when start_market_stream
    ->  for edge price

* BybytMarket::download_gap
    Add verbose print
    Fix: when gap is end with now(time:0)