### PR TITLE
Progressbar

### DIFF
--- a/rbot/Cargo.toml
+++ b/rbot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbot"
-version = "0.1.0"       # for test pypi
+version = "0.1.1"       # for test pypi
 # version = "0.4.0"     # for main release branch
 edition = "2021"
 exclude = ["test/**"]

--- a/rbot_lib/src/common/env.rs
+++ b/rbot_lib/src/common/env.rs
@@ -52,7 +52,12 @@ pub fn is_notebook() -> bool {
         let notebook = PyModule::from_code_bound(
             py,
             r#"
+import sys
+
 def is_notebook() -> bool:
+    if 'google.colab' in sys.modules:
+        return True               
+
     try:
         shell = get_ipython().__class__.__name__
         if shell == "ZMQInteractiveShell":

--- a/rbot_session/src/runner.rs
+++ b/rbot_session/src/runner.rs
@@ -115,7 +115,7 @@ impl Runner {
         self.last_print_real_time = 0;
     }
 
-    #[pyo3(signature = (*, exchange, market, agent, start_time=0, end_time=0, execute_time=0, verbose=false, log_memory=false, log_file=None))]
+    #[pyo3(signature = (*, exchange, market, agent, start_time=0, end_time=0, execute_time=0, verbose=false, log_memory=true, log_file=None))]
     pub fn back_test(
         &mut self,
         exchange: &Bound<PyAny>,


### PR DESCRIPTION
BackTEST のlog_memoryフラグをディフォルトTrueへ（FIX)
google clabであるかを確認し、tqdm.notebookを利用するように変更
version 0.1.1へ変更（test pypi用）